### PR TITLE
add option to pause after viewport changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ exports.config = {
       diffName: getScreenshotName(path.join(process.cwd(), 'screenshots/diff')),
       misMatchTolerance: 0.01,
     }),
+    viewportChangePause: 300
   },
   // ...
 };
@@ -60,7 +61,10 @@ exports.config = {
 Under the key `visualRegression` in your wdio.config.js you can pass a configuration object with the following structure:
 
 * **compare** `Object` <br>
-  screenshot compare method, see [Compare Methods](#compare-methods)
+screenshot compare method, see [Compare Methods](#compare-methods)
+
+* **viewportChangePause**  `Number`  ( default: 100 ) <br>
+wait x milliseconds after viewport change. It can take a while for the browser to re-paint. This could lead to rendering issues and produces inconsistent results between runs.
 
 ### Compare Methods
 wdio-visual-regression-service allows the usage of different screenshot comparison methods.
@@ -113,6 +117,9 @@ available:
 
 * **misMatchTolerance** `Number` <br>
     Overrides the global *misMatchTolerance* value for this command. Pass in a number between 0 and 100 that defines the degree of mismatch to consider two images as identical,
+
+* **viewportChangePause**  `Number` <br>
+    Overrides the global *viewportChangePause* value for this command. Wait x milliseconds after viewport change.
 
 ### License
 

--- a/src/VisualRegressionLauncher.js
+++ b/src/VisualRegressionLauncher.js
@@ -24,6 +24,7 @@ export default class VisualRegressionLauncher {
     this.validateConfig(browser.options);
 
     this.compare = browser.options.visualRegression.compare;
+    this.viewportChangePause = _.get(browser.options, 'visualRegression.viewportChangePause', 100);
     const userAgent = (await browser.execute(getUserAgent)).value;
     const { name, version, ua } = parsePlatform(userAgent);
 
@@ -94,6 +95,8 @@ export default class VisualRegressionLauncher {
     const resolutionKeyPlural = browser.isMobile ? 'orientations' : 'widths';
     const resolutionMap = browser.isMobile ? mapOrientations : mapWidths;
 
+    const viewportChangePauseDefault = this.viewportChangePause;
+
     return async function async(...args) {
       const url = await browser.getUrl();
 
@@ -109,8 +112,9 @@ export default class VisualRegressionLauncher {
       } = options;
 
       const resolutions = options[resolutionKeyPlural];
+      const viewportChangePause = _.get(options, 'viewportChangePause', viewportChangePauseDefault);
 
-      const results = await resolutionMap(browser, resolutions, async function(resolution) {
+      const results = await resolutionMap(browser, viewportChangePause, resolutions, async function(resolution) {
         const meta = _.pickBy({
           url,
           element: elementSelector,

--- a/src/modules/mapViewports.js
+++ b/src/modules/mapViewports.js
@@ -1,4 +1,4 @@
-export async function mapWidths(browser, widths = [], iteratee) {
+export async function mapWidths(browser, delay, widths = [], iteratee) {
   const results = [];
 
   if (!widths.length) {
@@ -8,6 +8,7 @@ export async function mapWidths(browser, widths = [], iteratee) {
   } else {
     for (let width of widths) {
       await browser.windowHandleSize({width, height: 1000});
+      await browser.pause(delay);
       const result = await iteratee(width);
       results.push(result);
     }
@@ -16,7 +17,7 @@ export async function mapWidths(browser, widths = [], iteratee) {
   return results;
 }
 
-export async function mapOrientations(browser, orientations = [], iteratee) {
+export async function mapOrientations(browser, delay, orientations = [], iteratee) {
   const results = [];
 
   if (!orientations.length) {
@@ -26,6 +27,7 @@ export async function mapOrientations(browser, orientations = [], iteratee) {
   } else {
     for (let orientation of orientations) {
       await browser.setOrientation(orientation);
+      await browser.pause(delay);
       const result = await iteratee(orientation);
       results.push(result);
     }

--- a/test/wdio/wdio.config.js
+++ b/test/wdio/wdio.config.js
@@ -34,5 +34,6 @@ exports.config = {
   ],
   visualRegression: {
     compare: compareMethod,
+    viewportChangePause: 250
   }
 }


### PR DESCRIPTION
Addresses #2 

This PR adds the option `viewportChangePause` to allow the definition of a custom wait duration.

* globally for all commands
* for each command individually