### PR TITLE
delete existing/old diff image when image is no longer different

### DIFF
--- a/src/methods/LocalCompare.js
+++ b/src/methods/LocalCompare.js
@@ -34,8 +34,9 @@ export default class LocalCompare extends BaseCompare {
       const misMatchPercentage = Number(compareData.misMatchPercentage);
       const misMatchTolerance = _.get(context, 'options.misMatchTolerance', this.misMatchTolerance);
 
+      const diffPath = this.getDiffFile(context);
+
       if (misMatchPercentage > misMatchTolerance) {
-        const diffPath = this.getDiffFile(context);
         log(`Image is different! ${misMatchPercentage}%`);
         const png = compareData.getDiffImage().pack();
         await this.writeDiff(png, diffPath);
@@ -44,6 +45,7 @@ export default class LocalCompare extends BaseCompare {
       } else {
         log(`Image is within tolerance or the same. Updating base image`);
         await fs.outputFile(referencePath, base64Screenshot, 'base64');
+        await fs.remove(diffPath);
 
         return this.createResultReport(misMatchPercentage, true, isSameDimensions);
       }

--- a/test/unit/methods/LocalCompare.test.js
+++ b/test/unit/methods/LocalCompare.test.js
@@ -178,6 +178,33 @@ describe('LocalCompare', function () {
       await compareImages(this.diffFile, path.join(dirFixture, 'image/100x100-diff.png'))
     });
 
+    it('deletes existing diff image when image is in tolerance now', async function () {
+      const base64ScreenshotReference = await readAsBase64(path.join(dirFixture, 'image/100x100.png'));
+      const base64ScreenshotNew = await readAsBase64(path.join(dirFixture, 'image/100x100-rotated.png'));
+
+      // 1st run -> create reference
+      await this.localCompare.afterScreenshot({}, base64ScreenshotReference);
+
+      // 2nd run --> create diff image
+      await this.localCompare.afterScreenshot({}, base64ScreenshotNew);
+
+      // check if diff image was created
+      let existsDiff = await fs.exists(this.diffFile);
+      assert.isTrue(existsDiff, 'Diff screenshot should exist');
+
+      // 3rd run --> update reference image & delete existing diff
+      const context = {
+        options: {
+            misMatchTolerance: 100,
+        }
+      };
+      await this.localCompare.afterScreenshot(context, base64ScreenshotNew);
+
+      // check if diff image was deleted
+      existsDiff = await fs.exists(this.diffFile);
+      assert.isFalse(existsDiff, 'Diff screenshot should no longer exist');
+    });
+
   });
 
 


### PR DESCRIPTION
If an diff image becomes obsolete, it should be deleted. 

Reasons for becoming obsolete:
* bugs that are causing this diff are fixed
* adjusted misMatchTolerance in tests
