### PR TITLE
Jimp supersedes GraphicsMagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@
 
 wdio-visual-regression-service uses [wdio-screenshot](https://github.com/zinserjan/wdio-screenshot) for capturing screenhots.
 
-As [wdio-screenshot](https://github.com/zinserjan/wdio-screenshot) depends on [GraphicsMagick](http://www.graphicsmagick.org/) you have to install GraphicsMagick before you can use this. For installation instructions please read the [installation section](https://github.com/zinserjan/wdio-screenshot#installation) of wdio-screenshot.
-
-
-After these dependencies are installed you can install wdio-screenshot via NPM as usual:
+You can install wdio-visual-regression-service via NPM as usual:
 
 ```sh
 $ npm install wdio-visual-regression-service --save-dev

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.13.1",
     "node-resemble-js": "0.0.5",
     "platform": "^1.3.1",
-    "wdio-screenshot": "^0.1.0"
+    "wdio-screenshot": "^0.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",
@@ -49,7 +49,6 @@
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",
-    "gm": "^1.22.0",
     "mocha": "^2.4.5",
     "phantomjs": "^1.9.20",
     "rimraf": "^2.5.2",

--- a/test/helper/compareImages.js
+++ b/test/helper/compareImages.js
@@ -1,16 +1,14 @@
 import {
   assert
 } from 'chai';
-import gm from 'gm';
+import resemble from 'node-resemble-js';
 
 export default function compareImages(image1, image2) {
-  return new Promise((resolve, reject) => {
-    gm.compare(image1, image2, function(err, isEqual, equality, raw) {
-      if (err) {
-        return reject(err);
-      }
-      assert.isTrue(isEqual);
-      assert.closeTo(equality, 0, 0.0001);
+  return new Promise((resolve) => {
+    const image = resemble(image1).compareTo(image2);
+    image.onComplete((data) => {
+      assert.isTrue(data.isSameDimensions);
+      assert.closeTo(Number(data.misMatchPercentage), 0, 0.0001);
       resolve();
     });
   });


### PR DESCRIPTION
wdio-screenshot does no longer need GraphicsMagick as a external dependency (zinserjan/wdio-screenshot#10).