### PR TITLE
fix npm install issues with node-gyp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: node_js
 node_js:
   - "4"
   - "5"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - g++-4.8
 
 before_install:
   - sudo apt-get update


### PR DESCRIPTION
Build fails in #23 cause of missing binaries for `fibers`. This PR adds a way to compile them with node-gyp to avoid failures in the future..