### PR TITLE
CI: start browsers automatically via selenium-standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 # project
 .tmp
 lib
+logs

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "rimraf": "^2.5.2",
     "sinon": "^1.17.4",
     "wdio-mocha-framework": "^0.3.1",
+    "wdio-selenium-standalone-service": "0.0.7",
     "webdriverio": "^4.0.9"
   }
 }

--- a/test/wdio/wdio.config.js
+++ b/test/wdio/wdio.config.js
@@ -8,9 +8,12 @@ exports.config = {
   specs: [
     path.join(__dirname, '*.test.js')
   ],
-  capabilities: [{
-    browserName: 'phantom'
-  }],
+  capabilities: [
+    {
+      browserName: 'phantomjs',
+      'phantomjs.binary.path': require('phantomjs').path,
+    }
+  ],
   sync: false,
   logLevel: 'silent',
   coloredLogs: true,
@@ -30,11 +33,15 @@ exports.config = {
     ],
   },
   services: [
+    'selenium-standalone',
     require('../../src')
   ],
   visualRegression: {
     compare: compareMethod,
     viewportChangePause: 250,
     widths: [600],
-  }
+  },
+  // Options for selenium-standalone
+  // Path where all logs from the Selenium server should be stored.
+  seleniumLogs: './logs/',
 }


### PR DESCRIPTION
This makes testing much easier as it just works. You don't have to start phantomjs yourself to run the integration tests.