### PR TITLE
bump wdio-screenshot to support latest firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lodash": "^4.13.1",
     "node-resemble-js": "0.0.5",
     "platform": "^1.3.1",
-    "wdio-screenshot": "^0.2.0"
+    "wdio-screenshot": "^0.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",


### PR DESCRIPTION
Adjust the version constraint to get latest wdio-screenshot with [support for latest firefox](https://github.com/zinserjan/wdio-screenshot/releases/tag/v0.4.0)