### PR TITLE
Add screen width to Visual Regression example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ function getScreenshotName(basePath) {
     var testName = context.test.title;
     var browserVersion = parseInt(context.browser.version, 10);
     var browserName = context.browser.name;
+    var browserWidth = context.meta.width;
 
-    return path.join(basePath, `${testName}_${type}_${browserName}_v${browserVersion}.png`);
+    return path.join(basePath, `${testName}_${type}_${browserName}_v${browserVersion}_${browserWidth}.png`);
   };
 }
 


### PR DESCRIPTION
This is to avoid an issue where having multiple screen widths causes filenames to override themselves.

See https://github.com/webdriverio/webdriverio/pull/1898