### PR TITLE
Allow viewport configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ function getScreenshotName(basePath) {
     var testName = context.test.title;
     var browserVersion = parseInt(context.browser.version, 10);
     var browserName = context.browser.name;
-    var browserWidth = context.meta.width;
+    var browserViewport = context.meta.viewport;
+    var browserWidth = browserViewport.width;
+    var browserHeight = browserViewport.height;
 
-    return path.join(basePath, `${testName}_${type}_${browserName}_v${browserVersion}_${browserWidth}.png`);
+    return path.join(basePath, `${testName}_${type}_${browserName}_v${browserVersion}_${browserWidth}x${browserHeight}.png`);
   };
 }
 
@@ -51,7 +53,7 @@ exports.config = {
       misMatchTolerance: 0.01,
     }),
     viewportChangePause: 300,
-    widths: [320, 480, 640, 1024],
+    viewports: [{ width: 320, height: 480 }, { width: 480, height: 320 }, { width: 1024, height: 768 }],
     orientations: ['landscape', 'portrait'],
   },
   // ...
@@ -67,8 +69,8 @@ screenshot compare method, see [Compare Methods](#compare-methods)
 * **viewportChangePause**  `Number`  ( default: 100 ) <br>
 wait x milliseconds after viewport change. It can take a while for the browser to re-paint. This could lead to rendering issues and produces inconsistent results between runs.
 
-* **widths** `Number[]`  ( default: *[current-width]* ) (**desktop only**)<br>
-   all screenshots will be taken in different screen widths (e.g. for responsive design tests)
+* **viewports** `Object[{ width: Number, height: Number }]`  ( default: *[current-viewport]* ) (**desktop only**)<br>
+   all screenshots will be taken in different viewport dimensions (e.g. for responsive design tests)
 
 * **orientations** `String[] {landscape, portrait}`  ( default: *[current-orientation]* ) (**mobile only**)<br>
     all screenshots will be taken in different screen orientations (e.g. for responsive design tests)
@@ -124,8 +126,8 @@ available:
 * **remove** `String[]`<br>
   removes all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `display: none`)
 
-* **widths** `Number[]` (**desktop only**)<br>
-     Overrides the global *widths* value for this command. All screenshots will be taken in different screen widths (e.g. for responsive design tests)
+* **viewports** `Object[{ width: Number, height: Number }]` (**desktop only**)<br>
+     Overrides the global *viewports* value for this command. All screenshots will be taken in different viewport dimensions (e.g. for responsive design tests)
 
 * **orientations** `String[] {landscape, portrait}` (**mobile only**)<br>
     Overrides the global *orientations* value for this command. All screenshots will be taken in different screen orientations (e.g. for responsive design tests)

--- a/src/VisualRegressionLauncher.js
+++ b/src/VisualRegressionLauncher.js
@@ -3,7 +3,7 @@ import { parse as parsePlatform } from 'platform';
 import { makeElementScreenshot, makeDocumentScreenshot, makeViewportScreenshot } from 'wdio-screenshot';
 
 import getUserAgent from './scripts/getUserAgent';
-import { mapWidths, mapOrientations } from './modules/mapViewports';
+import { mapViewports, mapOrientations } from './modules/mapViewports';
 
 
 export default class VisualRegressionLauncher {
@@ -25,7 +25,7 @@ export default class VisualRegressionLauncher {
 
     this.compare = browser.options.visualRegression.compare;
     this.viewportChangePause = _.get(browser.options, 'visualRegression.viewportChangePause', 100);
-    this.widths = _.get(browser.options, 'visualRegression.widths');
+    this.viewports = _.get(browser.options, 'visualRegression.viewports');
     this.orientations = _.get(browser.options, 'visualRegression.orientations');
     const userAgent = (await browser.execute(getUserAgent)).value;
     const { name, version, ua } = parsePlatform(userAgent);
@@ -93,12 +93,12 @@ export default class VisualRegressionLauncher {
       return _.pick(this.currentTest, ['title', 'parent', 'file']);
     };
 
-    const resolutionKeySingle = browser.isMobile ? 'orientation' : 'width';
-    const resolutionKeyPlural = browser.isMobile ? 'orientations' : 'widths';
-    const resolutionMap = browser.isMobile ? mapOrientations : mapWidths;
+    const resolutionKeySingle = browser.isMobile ? 'orientation' : 'viewport';
+    const resolutionKeyPlural = browser.isMobile ? 'orientations' : 'viewports';
+    const resolutionMap = browser.isMobile ? mapOrientations : mapViewports;
 
     const viewportChangePauseDefault = this.viewportChangePause;
-    const resolutionDefault = browser.isMobile ? this.orientations : this.widths;
+    const resolutionDefault = browser.isMobile ? this.orientations : this.viewports;
 
     return async function async(...args) {
       const url = await browser.getUrl();
@@ -110,8 +110,6 @@ export default class VisualRegressionLauncher {
         exclude,
         hide,
         remove,
-        widths,
-        orientations
       } = options;
 
       const resolutions = _.get(options, resolutionKeyPlural, resolutionDefault);

--- a/src/modules/mapViewports.js
+++ b/src/modules/mapViewports.js
@@ -1,15 +1,15 @@
-export async function mapWidths(browser, delay, widths = [], iteratee) {
+export async function mapViewports(browser, delay, viewports = [], iteratee) {
   const results = [];
 
-  if (!widths.length) {
-    const {width} = await browser.getViewportSize();
-    const result = await iteratee(width);
+  if (!viewports.length) {
+    const viewport = await browser.getViewportSize();
+    const result = await iteratee(viewport);
     results.push(result);
   } else {
-    for (let width of widths) {
-      await browser.setViewportSize({width, height: 1000});
+    for (let viewport of viewports) {
+      await browser.setViewportSize(viewport);
       await browser.pause(delay);
-      const result = await iteratee(width);
+      const result = await iteratee(viewport);
       results.push(result);
     }
   }

--- a/test/wdio/VisualRegressionLauncher.test.js
+++ b/test/wdio/VisualRegressionLauncher.test.js
@@ -96,9 +96,9 @@ function assertMeta(meta, type, options) {
     assert.strictEqual(meta.remove, options.remove);
   }
 
-  if (typeof options.widths !== 'undefined') {
-    assert.property(meta, 'width');
-    assert.oneOf(meta.width, options.widths);
+  if (typeof options.viewports !== 'undefined') {
+    assert.property(meta, 'viewport');
+    assert.oneOf(meta.viewport, options.viewports);
   }
 
   if (typeof options.orientations !== 'undefined') {
@@ -230,7 +230,7 @@ describe('VisualRegressionLauncher - custom compare method & hooks', function ()
 
     it('uses a custom delay passed in constructor options', async function () {
       await browser.checkViewport({
-        widths: [500],
+        viewports: [{ width: 500, height: 1000 }],
       });
 
       assert.isTrue(browser.pause.calledAfter(browser.setViewportSize), 'browser.pause should have been after setViewportSize');
@@ -239,7 +239,7 @@ describe('VisualRegressionLauncher - custom compare method & hooks', function ()
 
     it('uses a custom delay passed in command options', async function () {
       await browser.checkViewport({
-        widths: [500],
+        viewports: [{ width: 500, height: 1000 }],
         viewportChangePause: 1500,
       });
 
@@ -248,7 +248,7 @@ describe('VisualRegressionLauncher - custom compare method & hooks', function ()
     });
   });
 
-  context('widths', function () {
+  context('viewports', function () {
 
     beforeEach(function () {
       spy(browser, 'setViewportSize');
@@ -258,23 +258,23 @@ describe('VisualRegressionLauncher - custom compare method & hooks', function ()
       browser.setViewportSize.restore();
     });
 
-    it('uses width passed in constructor options', async function () {
-      const expectedWidth = browser.options.visualRegression.widths[0];
+    it('uses viewport passed in constructor options', async function () {
+      const expectedViewport = browser.options.visualRegression.viewports[0];
       await browser.checkViewport();
 
-      const { width } = browser.setViewportSize.args[0][0];
-      assert.strictEqual(width, expectedWidth, 'browser.setViewportSize should have been called with global value');
+      const viewport = browser.setViewportSize.args[0][0];
+      assert.deepEqual(viewport, expectedViewport, 'browser.setViewportSize should have been called with global value');
     });
 
-    it('uses a custom width passed in command options', async function () {
-      const expectedWidth = 500;
+    it('uses a custom viewport passed in command options', async function () {
+      const expectedViewport = { width: 500, height: 600 };
 
       await browser.checkViewport({
-        widths: [expectedWidth],
+        viewports: [expectedViewport],
       });
 
-      const { width } = browser.setViewportSize.args[0][0];
-      assert.strictEqual(width, expectedWidth, 'browser.setViewportSize should have been called with custom value');
+      const viewport = browser.setViewportSize.args[0][0];
+      assert.deepEqual(viewport, expectedViewport, 'browser.setViewportSize should have been called with custom value');
     });
   });
 

--- a/test/wdio/wdio.config.js
+++ b/test/wdio/wdio.config.js
@@ -39,7 +39,7 @@ exports.config = {
   visualRegression: {
     compare: compareMethod,
     viewportChangePause: 250,
-    widths: [600],
+    viewports: [{ width: 600, height: 1000 }],
   },
   // Options for selenium-standalone
   // Path where all logs from the Selenium server should be stored.


### PR DESCRIPTION
Adresses #18 and #31.

Replaces `widths` option in favour of `viewports`. It's  breaking change and will be released as 0.8.0