### PR TITLE
Provide all test information in context object.

### DIFF
--- a/src/VisualRegressionLauncher.js
+++ b/src/VisualRegressionLauncher.js
@@ -89,9 +89,7 @@ export default class VisualRegressionLauncher {
 
     const runHook = this.runHook.bind(this);
 
-    const getTest = () => {
-      return _.pick(this.currentTest, ['title', 'parent', 'file']);
-    };
+    const getTest = () => this.currentTest;
 
     const resolutionKeySingle = browser.isMobile ? 'orientation' : 'viewport';
     const resolutionKeyPlural = browser.isMobile ? 'orientations' : 'viewports';


### PR DESCRIPTION
Use case: I would like to name the screenshot files using `test.fullName` but this is not currently available due to only a few properties being picked from `currentTest`.