### PR TITLE
added option to ignore comparison

### DIFF
--- a/src/methods/LocalCompare.js
+++ b/src/methods/LocalCompare.js
@@ -68,7 +68,7 @@ export default class LocalCompare extends BaseCompare {
     return await new Promise((resolve) => {
       const image = resemble(reference).compareTo(screenshot);
 
-      switch(ignoreComparison) {
+      switch(ignore) {
         case 'colors':
           image.ignoreColors();
           break;

--- a/src/methods/LocalCompare.js
+++ b/src/methods/LocalCompare.js
@@ -14,6 +14,7 @@ export default class LocalCompare extends BaseCompare {
     this.getReferencefile = options.referenceName;
     this.getDiffFile = options.diffName;
     this.misMatchTolerance = _.get(options, 'misMatchTolerance', 0.01);
+    this.ignoreComparison = _.get(options, 'ignoreComparison', '');
   }
 
   async afterScreenshot(context, base64Screenshot) {
@@ -63,10 +64,11 @@ export default class LocalCompare extends BaseCompare {
    * @return {{misMatchPercentage: Number, isSameDimensions:Boolean, getImageDataUrl: function}}
    */
   async compareImages(reference, screenshot, ignore = '') {
+    const ignoreComparison = ignore || this.ignoreComparison;
     return await new Promise((resolve) => {
       const image = resemble(reference).compareTo(screenshot);
 
-      switch(ignore) {
+      switch(ignoreComparison) {
         case 'colors':
           image.ignoreColors();
           break;

--- a/src/methods/LocalCompare.js
+++ b/src/methods/LocalCompare.js
@@ -28,8 +28,9 @@ export default class LocalCompare extends BaseCompare {
     if (referenceExists) {
       log('reference exists, compare it with the taken now');
       const captured = new Buffer(base64Screenshot, 'base64');
+      const ignoreComparison = _.get(context, 'options.ignoreComparison', this.ignoreComparison);
 
-      const compareData = await this.compareImages(referencePath, captured);
+      const compareData = await this.compareImages(referencePath, captured, ignoreComparison);
 
       const { isSameDimensions } = compareData;
       const misMatchPercentage = Number(compareData.misMatchPercentage);
@@ -64,7 +65,6 @@ export default class LocalCompare extends BaseCompare {
    * @return {{misMatchPercentage: Number, isSameDimensions:Boolean, getImageDataUrl: function}}
    */
   async compareImages(reference, screenshot, ignore = '') {
-    const ignoreComparison = ignore || this.ignoreComparison;
     return await new Promise((resolve) => {
       const image = resemble(reference).compareTo(screenshot);
 


### PR DESCRIPTION
Based on https://github.com/zinserjan/wdio-visual-regression-service/issues/45

I added the global option of `ignoreComparison`, so you can now pass it to the constructor. Eg

```
visualRegression: {
    compare: new VisualRegressionCompare.LocalCompare({
      referenceName: yourFunc,
      screenshotName: yourFunc,
      diffName: yourFunc,
      misMatchTolerance: 3.0,
      ignoreComparison: 'colors'
    }),
  },
```

I also built a version which you can use immediately in your project until this gets merged: `npm i --save-dev https://github.com/purposeindustries/wdio-visual-regression-service/releases/download/ignore-comparison/wdio-visual-regression-service-0.8.0.tgz`

UPDATE: I added the option to pass the `ignoreComparison` locally, not just globally. So you can add it to `browser.checkViewport({ignoreComparison: 'colors'})`