### PR TITLE
 generate unique runtime configs per webdriverio execution

### DIFF
--- a/src/methods/BaseCompare.js
+++ b/src/methods/BaseCompare.js
@@ -1,4 +1,13 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+const runtimeConfigPath = __dirname;
+
 export default class BaseCompare {
+
+  constructor() {
+    this.configs = new Map();
+  }
 
   /**
    * Gets executed once before all workers get launched.
@@ -50,7 +59,66 @@ export default class BaseCompare {
     return Promise.resolve();
   }
 
+  /**
+   * Prepare runtime config for worker process
+   */
+  async saveRuntimeConfig(name, config) {
+    const file = this.getRuntimeConfigFileName(name);
+    await fs.writeJson(file, config, {
+      spaces: 2
+    });
+    this.configs.set(name, config);
+  }
 
+   /**
+   * Read prepared runtime config from launcher process
+   */
+  async getRuntimeConfig(name) {
+    // try to read from cache first
+    if (this.configs.has(name)) {
+      return this.configs.get(name);
+    }
+    // otherwise read from fs
+    const file = this.getRuntimeConfigFileName(name);
+    const config = await fs.readJson(file);
+    // and cache the result
+    this.configs.set(name, config);
+    return config;
+  }
+
+   /**
+   * Remove runtime config
+   */
+  async removeRuntimeConfig(name) {
+    // delete from fs
+    const file = this.getRuntimeConfigFileName(name);
+    await fs.remove(file);
+    // delete from cache
+    this.configs.delete(name);
+  }
+
+  /**
+   * Removes all created runtime configs
+   */
+  async cleanUpRuntimeConfigs() {
+    // clean up all saved config files
+    const names = [...this.configs.keys()];
+    await Promise.all(names.map((n) => this.removeRuntimeConfig(n)));
+  }
+
+  /**
+   * Builds a non-conflicting file name for this webdriverio run
+   */
+  getRuntimeConfigFileName(name) {
+    // launcher and runner gets the same arguments, so let's use them to build a hash to determine different calls
+    const hash = require("crypto").createHash('md5').update(process.argv.slice(2).join("")).digest('hex').substring(0, 4);
+    // try to use process id to generate a unique file name for each webdriverio instance
+    const runner = global.browser != null;
+    const pid = !process.hasOwnProperty("ppid") ? null : (runner ? process.ppid : process.pid);
+    // generate file name suffix
+    const suffix = [hash, pid].filter(Boolean).join("-");
+    return path.join(runtimeConfigPath, `${name}-${suffix}.json`);
+  }
 
   createResultReport(misMatchPercentage, isWithinMisMatchTolerance, isSameDimensions) {
     return {

--- a/src/methods/BaseCompare.js
+++ b/src/methods/BaseCompare.js
@@ -1,6 +1,8 @@
 import fs from 'fs-extra';
 import path from 'path';
+import debug from 'debug';
 
+const log = debug('wdio-visual-regression-service:BaseCompare');
 const runtimeConfigPath = __dirname;
 
 export default class BaseCompare {
@@ -64,6 +66,7 @@ export default class BaseCompare {
    */
   async saveRuntimeConfig(name, config) {
     const file = this.getRuntimeConfigFileName(name);
+    log(`Save runtime config ${name} to file ${file}`);
     await fs.writeJson(file, config, {
       spaces: 2
     });
@@ -76,10 +79,12 @@ export default class BaseCompare {
   async getRuntimeConfig(name) {
     // try to read from cache first
     if (this.configs.has(name)) {
+      log(`Read runtime config ${name} from cache`);
       return this.configs.get(name);
     }
     // otherwise read from fs
     const file = this.getRuntimeConfigFileName(name);
+    log(`Read runtime config ${name} from file ${file}`);
     const config = await fs.readJson(file);
     // and cache the result
     this.configs.set(name, config);
@@ -92,6 +97,7 @@ export default class BaseCompare {
   async removeRuntimeConfig(name) {
     // delete from fs
     const file = this.getRuntimeConfigFileName(name);
+    log(`Remove runtime config ${name} file ${file}`);
     await fs.remove(file);
     // delete from cache
     this.configs.delete(name);

--- a/src/methods/Spectre.js
+++ b/src/methods/Spectre.js
@@ -27,7 +27,6 @@ export default class Spectre extends BaseCompare {
     const result = await this.spectreClient.createTestrun(this.project, this.suite);
     log(`${creationOptions} - Testrun created - Run-Id: #${result.id}`);
     this.saveRuntimeConfig(runtimeConfigName, result);
-    log(`${creationOptions} - Saved Run-Id #${result.id} to ${this.getRuntimeConfigFileName(runtimeConfigName)}`);
   }
 
   async processScreenshot(context, base64Screenshot) {

--- a/src/methods/Spectre.js
+++ b/src/methods/Spectre.js
@@ -1,5 +1,3 @@
-import fs from 'fs-extra';
-import path from 'path';
 import BaseCompare from './BaseCompare';
 import debug from 'debug';
 import _ from 'lodash';
@@ -7,8 +5,7 @@ import _ from 'lodash';
 import SpectreClient from "nodeclient-spectre";
 
 const log = debug('wdio-visual-regression-service:Spectre');
-
-const pathToRunIDJson = path.join(__dirname, './run_id.json');
+const runtimeConfigName = 'spectre-run';
 
 export default class Spectre extends BaseCompare {
 
@@ -29,17 +26,13 @@ export default class Spectre extends BaseCompare {
     log(`${creationOptions} - Creating testrun`);
     const result = await this.spectreClient.createTestrun(this.project, this.suite);
     log(`${creationOptions} - Testrun created - Run-Id: #${result.id}`);
-    try{
-      await fs.writeJson(pathToRunIDJson, result);
-      log(`${creationOptions} - Saved Run-Id #${result.id} to ${pathToRunIDJson}`);
-    }
-    catch (e){
-      throw new Error(`Unable to write file to ${pathToRunIDJson}`);
-    }
+    this.saveRuntimeConfig(runtimeConfigName, result);
+    log(`${creationOptions} - Saved Run-Id #${result.id} to ${this.getRuntimeConfigFileName(runtimeConfigName)}`);
   }
 
   async processScreenshot(context, base64Screenshot) {
-    const testrunID = (await fs.readJson(pathToRunIDJson, 'utf8')).id;
+    const runDetails = await this.getRuntimeConfig(runtimeConfigName);
+    const testrunID = runDetails.id;
     const test = this.test(context);
     const browser = this.browser(context);
     const size = this.size(context);
@@ -62,10 +55,6 @@ export default class Spectre extends BaseCompare {
   }
 
   async onComplete() {
-    try {
-      await fs.remove(pathToRunIDJson);
-    } catch (e) {
-      throw new Error(`Unable to delete file ${pathToRunIDJson}`);
-    }
+    await this.cleanUpRuntimeConfigs();
   }
 }


### PR DESCRIPTION
Webdriverio's test runner does not provide any api to pass data from launcher to runner processes for custom services. #66 used a workaround to pass the data to the child process with a temporary file like suggested in webdriverio/webdriverio#1914. But the name of the file was fixed and leads to wrong results when running multiple instances of webdriverio at the same time.

This PR improves the workaround and avoids conflicts when you run several instances of webdriverio simultaneously. 

Running simultaneously the same config file requires a Node version with at least 6.13.0, 8.10.0, 9.2.0. In previous versions `process.ppid` isn't available. But this should be a edge case (maybe a wdio config that is configured via environment variables?).

Changes:
- move runtime config logic to BaseCompare -> every plugin can use this
- further calls to read the config are cached
- build a "unique" filename per webdriverio execution on the basis of the provided cli arguments and when available the process id.