### PR TITLE
Add isNewScreenshot to results

### DIFF
--- a/src/methods/BaseCompare.js
+++ b/src/methods/BaseCompare.js
@@ -126,12 +126,13 @@ export default class BaseCompare {
     return path.join(runtimeConfigPath, `${name}-${suffix}.json`);
   }
 
-  createResultReport(misMatchPercentage, isWithinMisMatchTolerance, isSameDimensions) {
+  createResultReport(misMatchPercentage, isWithinMisMatchTolerance, isSameDimensions, isNewScreenshot) {
     return {
       misMatchPercentage,
       isWithinMisMatchTolerance,
       isSameDimensions,
-      isExactSameImage: misMatchPercentage === 0
+      isExactSameImage: misMatchPercentage === 0,
+      isNewScreenshot
     };
   }
 

--- a/src/methods/LocalCompare.js
+++ b/src/methods/LocalCompare.js
@@ -43,18 +43,18 @@ export default class LocalCompare extends BaseCompare {
         const png = compareData.getDiffImage().pack();
         await this.writeDiff(png, diffPath);
 
-        return this.createResultReport(misMatchPercentage, false, isSameDimensions);
+        return this.createResultReport(misMatchPercentage, false, isSameDimensions, false);
       } else {
         log(`Image is within tolerance or the same`);
         await fs.remove(diffPath);
 
-        return this.createResultReport(misMatchPercentage, true, isSameDimensions);
+        return this.createResultReport(misMatchPercentage, true, isSameDimensions, false);
       }
 
     } else {
       log('first run - create reference file');
       await fs.outputFile(referencePath, base64Screenshot, 'base64');
-      return this.createResultReport(0, true, true);
+      return this.createResultReport(0, true, true, true);
     }
   }
 

--- a/src/methods/SaveScreenshot.js
+++ b/src/methods/SaveScreenshot.js
@@ -13,10 +13,11 @@ export default class SaveScreenshot extends BaseCompare {
 
   async processScreenshot(context, base64Screenshot) {
     const screenshotPath = this.getScreenshotFile(context);
+    const screenshotExists = await fs.exists(screenshotPath);
 
     log(`create screenshot file at ${screenshotPath}`);
     await fs.outputFile(screenshotPath, base64Screenshot, 'base64');
-    return this.createResultReport(0, true, true);
+    return this.createResultReport(0, true, true, !screenshotExists);
   }
 
 }

--- a/test/unit/methods/LocalCompare.test.js
+++ b/test/unit/methods/LocalCompare.test.js
@@ -58,15 +58,15 @@ describe('LocalCompare', function () {
         isExactSameImage: true,
         isNewScreenshot: false
       };
-    });
 
-    this.resultNewFile = {
-      misMatchPercentage: 0,
-      isWithinMisMatchTolerance: true,
-      isSameDimensions: true,
-      isExactSameImage: true
-    };
-  });
+      this.resultNewFile = {
+        misMatchPercentage: 0,
+        isWithinMisMatchTolerance: true,
+        isSameDimensions: true,
+        isExactSameImage: true,
+        isNewScreenshot: true
+      };
+    });
 
   it('creates the captured screenshot', async function () {
       const context = {};

--- a/test/unit/methods/LocalCompare.test.js
+++ b/test/unit/methods/LocalCompare.test.js
@@ -55,11 +55,20 @@ describe('LocalCompare', function () {
         misMatchPercentage: 0,
         isWithinMisMatchTolerance: true,
         isSameDimensions: true,
-        isExactSameImage: true
+        isExactSameImage: true,
+        isNewScreenshot: false
       };
     });
 
-    it('creates the captured screenshot', async function () {
+    this.resultNewFile = {
+      misMatchPercentage: 0,
+      isWithinMisMatchTolerance: true,
+      isSameDimensions: true,
+      isExactSameImage: true
+    };
+  });
+
+  it('creates the captured screenshot', async function () {
       const context = {};
       const base64Screenshot = await readAsBase64(path.join(dirFixture, 'image/100x100.png'));
 
@@ -85,7 +94,7 @@ describe('LocalCompare', function () {
       assert.isTrue(this.getReferenceFile.calledWithExactly(context), 'Reference getter should receive context as arg');
 
       // check image results
-      assert.deepEqual(results, this.resultIdentical, 'Result should be reported');
+      assert.deepEqual(results, this.resultNewFile, 'Result should be reported');
 
       // check if reference image was created
       const existsReference = await fs.exists(this.referencFile);
@@ -165,6 +174,7 @@ describe('LocalCompare', function () {
       assert.isFalse(resultSecond.isExactSameImage, 'Images should diff');
       assert.isFalse(resultSecond.isWithinMisMatchTolerance, 'Images should be marked as diff');
       assert.isTrue(resultSecond.isSameDimensions, 'Image dimensioms should be the same');
+      assert.isFalse(resultSecond.isNewScreenshot, 'Image should not be new screenshot')
 
       // check if reference is still the same
       const statsSecond = await fs.stat(this.referencFile);
@@ -272,6 +282,7 @@ describe('LocalCompare', function () {
         assert.isAbove(result.misMatchPercentage, this.misMatchTolerance, 'Images should diff');
         assert.isFalse(result.isExactSameImage, 'Images should diff');
         assert.isFalse(result.isWithinMisMatchTolerance, 'Images should be marked as diff');
+        assert.isFalse(result.isNewScreenshot, 'Image should not be new screenshot');
 
         // check if diff image was created
         const existsDiff = await fs.exists(this.diffFile);
@@ -307,6 +318,7 @@ describe('LocalCompare', function () {
         assert.isAtMost(result.misMatchPercentage, this.misMatchTolerance, 'Images should diff');
         assert.isFalse(result.isExactSameImage, 'Images should diff');
         assert.isTrue(result.isWithinMisMatchTolerance, 'Diff should be in tolerance');
+        assert.isFalse(result.isNewScreenshot, 'Image should not be new screenshot');
 
         // check if diff image was not created
         const existsDiff = await fs.exists(this.diffFile);
@@ -321,6 +333,7 @@ describe('LocalCompare', function () {
         assert.isAbove(result.misMatchPercentage, this.misMatchTolerance, 'Images should diff');
         assert.isFalse(result.isExactSameImage, 'Images should diff');
         assert.isFalse(result.isWithinMisMatchTolerance, 'Images should be marked as diff');
+        assert.isFalse(result.isNewScreenshot, 'Image should not be new screenshot');
 
         // check if diff image was created
         const existsDiff = await fs.exists(this.diffFile);
@@ -359,6 +372,7 @@ describe('LocalCompare', function () {
         assert.isAtMost(result.misMatchPercentage, this.misMatchTolerance, 'Images should diff');
         assert.isFalse(result.isExactSameImage, 'Images should diff');
         assert.isTrue(result.isWithinMisMatchTolerance, 'Diff should be in tolerance');
+        assert.isFalse(result.isNewScreenshot, 'Image should not be new screenshot');
 
         // check if diff image was not created
         const existsDiff = await fs.exists(this.diffFile);
@@ -373,6 +387,7 @@ describe('LocalCompare', function () {
         assert.isAbove(result.misMatchPercentage, this.misMatchTolerance, 'Images should diff');
         assert.isFalse(result.isExactSameImage, 'Images should diff');
         assert.isFalse(result.isWithinMisMatchTolerance, 'Images should be marked as diff');
+        assert.isFalse(result.isNewScreenshot, 'Image should not be new screenshot');
 
         // check if diff image was created
         const existsDiff = await fs.exists(this.diffFile);
@@ -424,6 +439,7 @@ describe('LocalCompare', function () {
         assert.isAbove(result.misMatchPercentage, 0, 'Images should diff');
         assert.isFalse(result.isExactSameImage, 'Images should diff');
         assert.isFalse(result.isWithinMisMatchTolerance, 'Diff should not be in tolerance');
+        assert.isFalse(result.isNewScreenshot, 'Image should not be new screenshot');
 
         // check if diff image was created
         const existsDiff = await fs.exists(this.diffFile);
@@ -457,6 +473,7 @@ describe('LocalCompare', function () {
         // check diff results
         assert.isTrue(result.isExactSameImage, 'Images should not diff');
         assert.isTrue(result.isWithinMisMatchTolerance, 'Diff should be in tolerance');
+        assert.isFalse(result.isNewScreenshot, 'Image should not be new screenshot');
 
         // check if diff image was not created
         const existsDiff = await fs.exists(this.diffFile);
@@ -494,6 +511,7 @@ describe('LocalCompare', function () {
         // check diff results
         assert.isTrue(result.isExactSameImage, 'Images should not diff');
         assert.isTrue(result.isWithinMisMatchTolerance, 'Diff should be in tolerance');
+        assert.isFalse(result.isNewScreenshot, 'Image should not be new screenshot');
 
         // check if diff image was not created
         const existsDiff = await fs.exists(this.diffFile);

--- a/test/unit/methods/LocalCompare.test.js
+++ b/test/unit/methods/LocalCompare.test.js
@@ -114,7 +114,7 @@ describe('LocalCompare', function () {
       assert.isTrue(this.getReferenceFile.calledWithExactly(context), 'Reference getter should receive context as arg');
 
       // check image results
-      assert.deepEqual(resultFirst, this.resultIdentical, 'Result should be reported');
+      assert.deepEqual(resultFirst, this.resultNewFile, 'Result should be reported');
 
       // check if reference was created
       const existsReference = await fs.exists(this.screenshotFile);
@@ -152,7 +152,7 @@ describe('LocalCompare', function () {
       assert.isTrue(this.getReferenceFile.calledWithExactly(context), 'Reference getter should receive context as arg');
 
       // check image results
-      assert.deepEqual(resultFirst, this.resultIdentical, 'Result should be reported');
+      assert.deepEqual(resultFirst, this.resultNewFile, 'Result should be reported');
 
       // check if reference was created
       const existsReference = await fs.exists(this.screenshotFile);

--- a/test/unit/methods/SaveScreenshot.test.js
+++ b/test/unit/methods/SaveScreenshot.test.js
@@ -95,7 +95,7 @@ describe('SaveScreenshot', function () {
       assert.isTrue(this.getReferenceFile.calledWithExactly(context), 'Reference getter should receive context as arg');
 
       // check image results
-      assert.deepEqual(resultFirst, this.resultIdentical, 'Result should be reported');
+      assert.deepEqual(resultFirst, this.resultNewFile, 'Result should be reported');
 
       // check if reference was created
       const existsReference = await fs.exists(this.referencFile);
@@ -136,7 +136,7 @@ describe('SaveScreenshot', function () {
       assert.isTrue(this.getReferenceFile.calledWithExactly(context), 'Reference getter should receive context as arg');
 
       // check image results
-      assert.deepEqual(resultFirst, this.resultIdentical, 'Result should be reported');
+      assert.deepEqual(resultFirst, this.resultNewFile, 'Result should be reported');
 
       // check if reference was created
       const existsReference = await fs.exists(this.referencFile);

--- a/test/unit/methods/SaveScreenshot.test.js
+++ b/test/unit/methods/SaveScreenshot.test.js
@@ -51,7 +51,16 @@ describe('SaveScreenshot', function () {
         misMatchPercentage: 0,
         isWithinMisMatchTolerance: true,
         isSameDimensions: true,
-        isExactSameImage: true
+        isExactSameImage: true,
+        isNewScreenshot: false
+      };
+
+      this.resultNewFile = {
+        misMatchPercentage: 0,
+        isWithinMisMatchTolerance: true,
+        isSameDimensions: true,
+        isExactSameImage: true,
+        isNewScreenshot: true
       };
     });
 
@@ -66,7 +75,7 @@ describe('SaveScreenshot', function () {
       assert.isTrue(this.getReferenceFile.calledWithExactly(context), 'Reference getter should receive context as arg');
 
       // check image results
-      assert.deepEqual(results, this.resultIdentical, 'Result should be reported');
+      assert.deepEqual(results, this.resultNewFile, 'Result should be reported');
 
       // check if reference image was created
       const existsReference = await fs.exists(this.referencFile);

--- a/test/unit/methods/Spectre.test.js
+++ b/test/unit/methods/Spectre.test.js
@@ -126,7 +126,8 @@ describe('Spectre', function () {
       misMatchPercentage: 0,
       isWithinMisMatchTolerance: true,
       isSameDimensions: true,
-      isExactSameImage: true
+      isExactSameImage: true,
+      isNewScreenshot: undefined,
     }, 'Result should be reported');
 
     nock(this.url)
@@ -167,6 +168,7 @@ describe('Spectre', function () {
       isWithinMisMatchTolerance: false,
       isSameDimensions: true,
       isExactSameImage: false,
+      isNewScreenshot: undefined,
     }, 'Result should be reported');
 
     await instance.onComplete();


### PR DESCRIPTION
Fixes #83

Note: I didn't attempt to get Spectre test to return the correct value for `isNewScreenshot`.

~~Note: I wasn't able to test locally as it's unhappy with my node version; I couldn't install the node dependencies.  Will update the ticket after I can either update dependencies or roll back my node version.~~